### PR TITLE
Add xeno-canto urls to species generator; closes #12

### DIFF
--- a/app/generator/api_combiner.rb
+++ b/app/generator/api_combiner.rb
@@ -1,27 +1,57 @@
 module ApiCombiner
+  attr_reader :trail_species
+
   def self.get_species(trail_id)
+    trail = Trail.find(trail_id)
+    @trail_species = []
+
+    add_gbif_species(trail.id, trail.lat, trail.lng)
+    add_xeno_canto_species(trail.id, trail.lat, trail.lng)
+  end
+
+  def self.add_gbif_species(trail_id, lat, lng)
+    xeno_canto = XenoCantoService.new
     gbif = GbifService.new
     eol = EolService.new
-    trail = Trail.find(trail_id)
-    trail_species = []
-
-    gbif_species = gbif.species(trail.lat, trail.lng)
+    gbif_species = gbif.species(lat, lng)
     gbif_species.each do |species|
       if species["species"]
         genus, spec = species["species"].split(" ")
         img = eol.image_from_species(genus, spec)
 
-        trail_species << Species.create(
+        @trail_species << Species.create(
           trail_id: trail_id,
           kingdom: species["kingdom"],
           scientific_name: species["species"],
           common_name: species["vernacularName"],
           photo_url: img,
-          clip_url: "not available",
+          clip_url: xeno_canto.species_recording(species["species"]),
           lat: species["decimalLatitude"],
           lng: species["decimalLongitude"])
       end
     end
-    trail_species
+  end
+
+  def self.add_xeno_canto_species(trail_id, lat, lng)
+    xeno_canto = XenoCantoService.new
+    eol = EolService.new
+
+    xeno_canto_species = xeno_canto.recordings(lat - 0.1, lng - 0.1,
+                                               lat + 0.1, lng + 0.1)
+    xeno_canto_species.each do |species|
+      if species["id"]
+        img = eol.image_from_species(species["gen"], species["sp"])
+
+        @trail_species << Species.create(
+          trail_id: trail_id,
+          kingdom: "Animalia",
+          scientific_name: "#{species['gen']} #{species['sp']}",
+          common_name: species["en"],
+          photo_url: img,
+          clip_url: species["file"],
+          lat: species["lat"],
+          lng: species["lng"])
+      end
+    end
   end
 end

--- a/app/generator/api_combiner.rb
+++ b/app/generator/api_combiner.rb
@@ -1,9 +1,6 @@
 module ApiCombiner
-  attr_reader :trail_species
-
   def self.get_species(trail_id)
     trail = Trail.find(trail_id)
-    @trail_species = []
 
     add_gbif_species(trail.id, trail.lat, trail.lng)
     add_xeno_canto_species(trail.id, trail.lat, trail.lng)
@@ -19,7 +16,7 @@ module ApiCombiner
         genus, spec = species["species"].split(" ")
         img = eol.image_from_species(genus, spec)
 
-        @trail_species << Species.create(
+        Species.create(
           trail_id: trail_id,
           kingdom: species["kingdom"],
           scientific_name: species["species"],
@@ -42,7 +39,7 @@ module ApiCombiner
       if species["id"]
         img = eol.image_from_species(species["gen"], species["sp"])
 
-        @trail_species << Species.create(
+        Species.create(
           trail_id: trail_id,
           kingdom: "Animalia",
           scientific_name: "#{species['gen']} #{species['sp']}",

--- a/app/generator/species_generator.rb
+++ b/app/generator/species_generator.rb
@@ -1,6 +1,6 @@
 class SpeciesGenerator
   def self.save_species
-    all_trails = Trail.all.limit(3)
+    all_trails = Trail.all.offset(1000).limit(3)
     all_trails.each do |trail|
       ApiCombiner.get_species(trail.id)
     end

--- a/app/services/xeno_canto_service.rb
+++ b/app/services/xeno_canto_service.rb
@@ -11,9 +11,23 @@ class XenoCantoService
       .get("recordings?query=box:#{min_lat},#{min_long},#{max_lat},#{max_long}"))
   end
 
+  def species_recording(species)
+    species_parse(connection
+      .get("recordings?query=#{species}"))
+  end
+
   private
 
   def parse(response)
     JSON.parse(response.body)["recordings"]
+  end
+
+  def species_parse(response)
+    body = JSON.parse(response.body)
+    if body["numRecordings"] == "0"
+      "not found"
+    else
+      body["recordings"][0]["file"]
+    end
   end
 end

--- a/test/generators/api_combiner_test.rb
+++ b/test/generators/api_combiner_test.rb
@@ -15,11 +15,11 @@ class ApiCombinerTest < ActiveSupport::TestCase
                          updated_at: "2015-04-07 20:14:51",
                          unique_id: 6039)
     VCR.use_cassette("api_combiner_recording") do
-      result = ApiCombiner.get_species(trail.id)
+      ApiCombiner.get_species(trail.id)
 
-      assert_equal 20, result.count
-      assert result[0].common_name
-      assert result[0].kingdom
+      assert_equal 22, Species.count
+      assert Species.first.common_name
+      assert Species.first.kingdom
     end
   end
 end

--- a/test/services/gbif_service_test.rb
+++ b/test/services/gbif_service_test.rb
@@ -11,7 +11,7 @@ class GbifServiceTest < ActiveSupport::TestCase
     VCR.use_cassette("gbif_service_species_recordings") do
       species = service.species(35.1, -95.9)
 
-      assert_equal "Petrochelidon pyrrhonota", species[0]
+      assert_equal "Petrochelidon pyrrhonota", species[0]["species"]
     end
   end
 end

--- a/test/services/xeno_canto_service_test.rb
+++ b/test/services/xeno_canto_service_test.rb
@@ -24,4 +24,18 @@ class XenoCantoServiceTest < ActiveSupport::TestCase
       assert_equal 0, recordings.length
     end
   end
+
+  test "recording by species" do
+    VCR.use_cassette("xeno_canto_service_species_recordings") do
+      recording = service.species_recording("troglodytes troglodytes")
+      assert_equal "http://www.xeno-canto.org/233278/download", recording
+    end
+  end
+
+  test "recording by species when not found" do
+    VCR.use_cassette("xeno_canto_service_fake_species_recordings") do
+      recording = service.species_recording("fake bird")
+      assert_equal "not found", recording
+    end
+  end
 end


### PR DESCRIPTION
This pull request adds additional logic to the SpeciesGenerator to add species to the database from the [Xeno Canto API](http://www.xeno-canto.org/article/153).

Changes include:
- Add species from Xeno Canto to the database.
- Add sound clip url(when available) to each species from the [GBIF API](http://gbif.blogspot.com/).
- Fix gbif_service_test.rb based on changes to the API processing.
